### PR TITLE
Issue #64: Only display the current pin on the picture page

### DIFF
--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -186,6 +186,9 @@ function osm_get_items($page)
     // SUBSTRING_INDEX(TRIM(LEADING '.' FROM `path`), '.', 1) full path without filename extension
     // SUBSTRING_INDEX(TRIM(LEADING '.' FROM `path`), '.', -1) full path with only filename extension
 
+
+    if (isset($page['image_id'])) $LIMIT_SEARCH .= 'i.id = ' . $page['image_id'] . ' AND ';
+
     $query="SELECT i.latitude, i.longitude,
     IFNULL(i.name, '') AS `name`,
     IF(i.representative_ext IS NULL,


### PR DESCRIPTION
Previous attempt to fix #64 introduced another bug.
The map on the picture page now contains info from all images of the album.
On this page we expect to see info (pin/thumbnail) from the current
image only.

This quick fix adds a sql limit condition to the query if the image_id param
exists (I assume that it means we come from the picture page?).
Note that it would be more efficient not to join in this case.