### PR TITLE
Fix for #87: gpx files should be .gpx$

### DIFF
--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -92,7 +92,7 @@ function osm_get_gps($page)
     /* Get all GPX tracks */
     $query="SELECT i.path FROM ".IMAGES_TABLE." AS i
             INNER JOIN (".IMAGE_CATEGORY_TABLE." AS ic ".$INNER_JOIN.") ON i.id = ic.image_id
-            WHERE ".$LIMIT_SEARCH." `path` LIKE '%gpx%' ".$forbidden." ";
+            WHERE ".$LIMIT_SEARCH." `path` LIKE '%.gpx' ".$forbidden." ";
 
     return array_from_query($query, 'path');
 }


### PR DESCRIPTION
The osm_get_gps function generates a sql query which retrieves all files
containing "gpx".
Instead it should retrieves files with a filename ending with ".gpx".

Otherwise the map won't display anything because of a JS error
"TypeError: omnivore.png is not a function" (in the case of a png file).