### PR TITLE
Fix #93: Do not autocenter if params are passed in the url

### DIFF
--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -520,7 +520,7 @@ function osm_get_js($conf, $local_conf, $js_data)
     }
     $js .= "\nif (typeof L.MarkerClusterGroup === 'function')\n";
     $js .= "    " . $divname . ".addLayer(markers);\n";
-    if ( $autocenter ) {
+    if ( $autocenter and !isset($_GET['center_lat']) and !isset($_GET['center_lng']) and !isset($_GET['zoom']) ) {
         $js .= "var group = new L.featureGroup(MarkerClusterList);";
         $js .= "this." . $divname . ".whenReady(function () {
         window.setTimeout(function () {


### PR DESCRIPTION
if center_lat, center_lng and zoom are passed via GET, it means that we
have generate a link from the map ("Link to this map").
In this case, if the autocenter feature is enabled, the map should not
autocenter.