### PR TITLE
Fix total digits for logitude column of osm_place_table

### DIFF
--- a/admin/admin_place.php
+++ b/admin/admin_place.php
@@ -41,7 +41,7 @@ define('osm_place_table', $prefixeTable.'osm_places');
 $q = 'CREATE TABLE IF NOT EXISTS `'.osm_place_table.'` (
                 `id` mediumint(8) unsigned NOT NULL AUTO_INCREMENT,
                 `latitude` double(8,6) NOT NULL,
-                `longitude` double(8,6) NOT NULL,
+                `longitude` double(9,6) NOT NULL,
                 `name` varchar(255) DEFAULT NULL,
                 `parentId` mediumint(8),
                 PRIMARY KEY (id)


### PR DESCRIPTION
The valid range of latitude in degrees is -90 and +90 for the southern and northern hemisphere respectively. Longitude is in the range -180 and +180 specifying coordinates west and east of the Prime Meridian, respectively.

You are able to set the correct latitude and longitude on a specific picture, but not as a place. It seems the logitude column in osm_place_table needs to have 9 total digits instead of 8. Otherwise the longitude is restricted to between -99.999999 and +99.999999.