### PR TITLE
 new function to better feed get_image_ids_for_tags when pages got multiple tags

### DIFF
--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -308,7 +308,7 @@ function osm_get_js($conf, $local_conf, $js_data)
         : 0;
     
     // When gallery is SSL and when switching baselayerURL to https is possible
-    $httpx = $_SERVER['REQUEST_SCHEME'];
+    $httpx = (!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS']) !== 'off')?'https':'http';
 
     // Load baselayerURL
     if     ($baselayer == 'mapnik')     $baselayerurl = $httpx.'://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';

--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -142,7 +142,7 @@ function osm_get_items($page)
 
         foreach (array('min_lat', 'min_lng', 'max_lat', 'max_lng') as $get_key)
         {
-                check_input_parameter($get_key, $_GET, false, '/^\d+(\.\d+)?$/');
+                check_input_parameter($get_key, $_GET, false, '/^-?\d+(\.\d+)?$/');
         }
 
         /* Delete all previous album */

--- a/include/functions_map.php
+++ b/include/functions_map.php
@@ -306,18 +306,21 @@ function osm_get_js($conf, $local_conf, $js_data)
     $autocenter = isset($local_conf['autocenter'])
         ? $local_conf['autocenter']
         : 0;
+    
+    // When gallery is SSL and when switching baselayerURL to https is possible
+    $httpx = $_SERVER['REQUEST_SCHEME'];
 
     // Load baselayerURL
-    if     ($baselayer == 'mapnik')     $baselayerurl = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+    if     ($baselayer == 'mapnik')     $baselayerurl = $httpx.'://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
     else if($baselayer == 'mapquest')   $baselayerurl = 'http://otile1.mqcdn.com/tiles/1.0.0/osm/{z}/{x}/{y}.png';
-    else if($baselayer == 'mapnikde')   $baselayerurl = 'https://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png';
-    else if($baselayer == 'mapnikfr')   $baselayerurl = 'https://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png';
+    else if($baselayer == 'mapnikde')   $baselayerurl = $httpx.'://{s}.tile.openstreetmap.de/tiles/osmde/{z}/{x}/{y}.png';
+    else if($baselayer == 'mapnikfr')   $baselayerurl = $httpx.'://{s}.tile.openstreetmap.fr/osmfr/{z}/{x}/{y}.png';
     else if($baselayer == 'blackandwhite')  $baselayerurl = 'http://{s}.www.toolserver.org/tiles/bw-mapnik/{z}/{x}/{y}.png';
-    else if($baselayer == 'mapnikhot')  $baselayerurl = 'https://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
+    else if($baselayer == 'mapnikhot')  $baselayerurl = $httpx.'://{s}.tile.openstreetmap.fr/hot/{z}/{x}/{y}.png';
     else if($baselayer == 'mapquestaerial') $baselayerurl = 'http://otile1.mqcdn.com/tiles/1.0.0/sat/{z}/{x}/{y}.png';
-    else if($baselayer == 'toner') $baselayerurl = 'https://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png';
+    else if($baselayer == 'toner') $baselayerurl = $httpx.'://stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png';
     else if($baselayer == 'custom') $baselayerurl = $custombaselayerurl;
-    else if($baselayer == 'esri') $baselayerurl = 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
+    else if($baselayer == 'esri') $baselayerurl = $httpx.'://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}';
 
     $attribution = osmcopyright($attrleaflet, $attrimagery, $attrmodule, $baselayer, $custombaselayer);
 


### PR DESCRIPTION
Currently, there is a bug when multiple tags are used on a piwigo page : pictures list in pwg-osm is filtered with only the first tag.
So I made a function to use with array_reduce